### PR TITLE
Fix CI: install ffmpeg as system dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 


### PR DESCRIPTION
## Summary
- Adds `ffmpeg` installation step to the CI workflow, fixing the `RuntimeWarning: Couldn't find ffmpeg or avconv` warning from pydub
- The Dockerfile already includes ffmpeg; this brings the CI environment in line

## Test plan
- [ ] Verify CI pipeline passes without the ffmpeg warning

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)