### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.env
+.env.*
+.git
+.github
+.claude
+.devcontainer
+.gitignore
+.python-version
+__pycache__
+*.egg-info
+test/


### PR DESCRIPTION
## Summary
- Adds `.dockerignore` to exclude `.env`, `.git`, tests, and other non-runtime files from the Docker build context
- Prevents accidental exposure of secrets (like `OPENAI_API_KEY`) in image layers

## Test plan
- [ ] Verify `docker build .` succeeds
- [ ] Verify `.env` is not present in the build context or final image

🤖 Generated with [Claude Code](https://claude.com/claude-code)