### PR TITLE
Add Docker image build to CI on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,29 @@ jobs:
         env:
           OPENAI_API_KEY: dummy
         run: uv run --with pytest pytest test/ -v
+
+  build-image:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}


### PR DESCRIPTION
## Summary
- Adds a `build-image` job to the CI workflow that runs after tests pass on pushes to `main`
- Builds the Docker image and pushes it to GitHub Container Registry (`ghcr.io`)
- Tags images with both `latest` and the commit SHA

## Test plan
- [ ] Merge to main and verify the `build-image` job runs after tests pass
- [ ] Confirm the image appears in the repo's GitHub Packages
- [ ] Verify PR builds do NOT trigger the image build

🤖 Generated with [Claude Code](https://claude.com/claude-code)