### PR TITLE
Copy README.md into Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-install-project --no-dev
 
 COPY src/ src/
+COPY README.md ./
 RUN uv sync --frozen --no-dev
 
 FROM python:3.12-slim


### PR DESCRIPTION
## Summary
- Adds `COPY README.md ./` to the Dockerfile builder stage so hatchling can find it during `uv sync --frozen --no-dev`

Fixes #13

## Test plan
- [ ] CI `build-image` job passes on this branch after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)