### PR TITLE
Add multi-arch Docker builds (amd64 + arm64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -54,6 +60,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
## Summary
- Adds QEMU and Buildx setup to the `build-image` CI job
- Builds Docker images for both `linux/amd64` and `linux/arm64` platforms

## Test plan
- [ ] CI `build-image` job passes after merge (depends on #14 landing first for the README.md fix)
- [ ] `docker manifest inspect ghcr.io/samanthavbarron/ad-begone:latest` shows both amd64 and arm64 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)