### PR TITLE
Make AI model configurable via CLI and env var

### DIFF
--- a/src/ad_begone/ad_trimmer.py
+++ b/src/ad_begone/ad_trimmer.py
@@ -3,7 +3,7 @@ from openai.types.chat.parsed_chat_completion import ParsedChatCompletion
 
 from .models import Window
 from .utils import (
-    DEFAULT_MODEL,
+    OPENAI_MODEL,
     cached_annotate_transcription,
     cached_transcription,
     find_ad_time_windows,
@@ -16,7 +16,7 @@ from .notif_path import NOTIF_PATH
 
 class AdTrimmer:
 
-    def __init__(self, file_name: str, model: str = DEFAULT_MODEL):
+    def __init__(self, file_name: str, model: str | None = OPENAI_MODEL):
         self.file_name = file_name
         self.model = model
         if not file_name.endswith(".mp3"):

--- a/src/ad_begone/remove_ads.py
+++ b/src/ad_begone/remove_ads.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from tqdm import tqdm
 
 from .ad_trimmer import AdTrimmer
-from .utils import DEFAULT_MODEL, join_files, split_file
+from .utils import OPENAI_MODEL, join_files, split_file
 
 from .notif_path import NOTIF_PATH
 
@@ -11,7 +11,7 @@ def remove_ads(
     out_name: str | None = None,
     notif_name: str = NOTIF_PATH,
     overwrite: bool = False,
-    model: str = DEFAULT_MODEL,
+    model: str | None = OPENAI_MODEL,
 ):
     if out_name is None:
         out_name = file_name
@@ -48,8 +48,8 @@ if __name__ == "__main__":
             default=None,
             description="Path to save the podcast episode file without ads.",
         )
-        model: str = pydantic.Field(
-            default=DEFAULT_MODEL,
+        model: Optional[str] = pydantic.Field(
+            default=OPENAI_MODEL,
             description="OpenAI model to use for ad classification.",
         )
 

--- a/src/ad_begone/watch_directory.py
+++ b/src/ad_begone/watch_directory.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 from time import sleep
 
+from typing import Optional
+
 import pydantic.v1 as pydantic
 import pydantic_argparse
 from tqdm import tqdm
 
 from .remove_ads import remove_ads
-from .utils import DEFAULT_MODEL
+from .utils import OPENAI_MODEL
 
 
 class WatchArgs(pydantic.BaseModel):
@@ -19,8 +21,8 @@ class WatchArgs(pydantic.BaseModel):
         gt=0,
         description="Sleep time in seconds between processing runs.",
     )
-    model: str = pydantic.Field(
-        default=DEFAULT_MODEL,
+    model: Optional[str] = pydantic.Field(
+        default=None,
         description="OpenAI model to use for ad classification.",
     )
 
@@ -28,7 +30,7 @@ class WatchArgs(pydantic.BaseModel):
 def walk_directory(
     directory: str,
     overwrite: bool = False,
-    model: str = DEFAULT_MODEL,
+    model: str | None = OPENAI_MODEL,
 ):
     queue = []
     for fn in Path(directory).rglob("*.mp3"):

--- a/test/test_ad_trimmer.py
+++ b/test/test_ad_trimmer.py
@@ -51,7 +51,7 @@ class TestAdTrimmer(TestCase):
         mock_cached_annotate.assert_called_once_with(
             transcription=mock_transcription,
             file_name="test.mp3.segments.json",
-            model="gpt-4o-2024-08-06",
+            model=None,
         )
 
     @patch("ad_begone.ad_trimmer.find_ad_time_windows")


### PR DESCRIPTION
## Summary
- Replaces raw `argparse` with `pydantic-argparse` for type-safe CLI argument parsing
- Adds `--model` flag to both `adwatch` and `remove_ads` CLIs for choosing the OpenAI classification model
- Falls back to `OPENAI_MODEL` environment variable, then defaults to `gpt-4o-2024-08-06`
- Fixes bug where `remove_ads.py` referenced undefined `args.notif_name`

Closes #16
Closes #18

## Test plan
- [x] All 63 existing tests pass
- [ ] Run `adwatch --model gpt-4o-mini --directory /path` and verify the specified model is used
- [ ] Set `OPENAI_MODEL=gpt-4o-mini` and verify the env var is picked up when no `--model` flag is given
- [ ] Verify default behavior is unchanged when neither `--model` nor `OPENAI_MODEL` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)