### PR TITLE
Fix model auto-detection selecting non-chat models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Run accuracy eval tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
         run: uv run --with pytest pytest test/test_accuracy_eval.py -v -s
 
       - name: Upload results

--- a/src/ad_begone/utils.py
+++ b/src/ad_begone/utils.py
@@ -75,13 +75,21 @@ def _get_model() -> str:
         return _RESOLVED_MODEL
 
     models = _get_client().models.list()
+    # Filter for chat-capable GPT models, excluding instruct/realtime/audio
+    # variants that only support the /v1/completions endpoint.
+    non_chat_keywords = ("instruct", "realtime", "audio")
     gpt_models = sorted(
-        (m for m in models if m.id.startswith("gpt-")),
+        (
+            m
+            for m in models
+            if m.id.startswith("gpt-")
+            and not any(kw in m.id for kw in non_chat_keywords)
+        ),
         key=lambda m: m.created,
         reverse=True,
     )
     if not gpt_models:
-        raise RuntimeError("No GPT models available from the OpenAI API")
+        raise RuntimeError("No chat-capable GPT models available from the OpenAI API")
     _RESOLVED_MODEL = gpt_models[0].id
     print(f"No OPENAI_MODEL set, using {_RESOLVED_MODEL}")
     return _RESOLVED_MODEL


### PR DESCRIPTION
## Summary
- The `_get_model()` auto-detection was picking up non-chat models (e.g. `gpt-3.5-turbo-instruct`) that only support `/v1/completions`, not `/v1/chat/completions`, causing 404 errors in the accuracy-eval CI job
- Filter out `instruct`/`realtime`/`audio` model variants from auto-detection
- Allow the accuracy-eval CI job to use the `OPENAI_MODEL` repository variable when set, as a safety net

## Test plan
- [x] Verify unit tests still pass on CI (`test` job)
- [ ] Verify accuracy-eval job passes (optionally set `OPENAI_MODEL` repo variable to a known chat model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)