### PR TITLE
Replace print() with structured logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ RUN apt-get update && \
 
 COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
 
 ENTRYPOINT ["ad-begone"]

--- a/compose.yml
+++ b/compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - LOG_FORMAT=json
     volumes:
       - ./podcasts:/data
     command: ["--directory", "/data"]

--- a/src/ad_begone/logging.py
+++ b/src/ad_begone/logging.py
@@ -1,0 +1,33 @@
+import json
+import logging
+import os
+import sys
+
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_record = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        return json.dumps(log_record)
+
+
+def setup_logging() -> None:
+    level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    log_format = os.environ.get("LOG_FORMAT", "text").lower()
+
+    handler = logging.StreamHandler(sys.stdout)
+
+    if log_format == "json":
+        handler.setFormatter(JSONFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+
+    root = logging.getLogger("ad_begone")
+    root.setLevel(level)
+    root.addHandler(handler)

--- a/src/ad_begone/remove_ads.py
+++ b/src/ad_begone/remove_ads.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from tqdm import tqdm
 
@@ -5,6 +6,8 @@ from .ad_trimmer import AdTrimmer
 from .utils import join_files, split_file
 
 from .notif_path import NOTIF_PATH
+
+logger = logging.getLogger(__name__)
 
 def remove_ads(
     file_name: str,
@@ -20,18 +23,18 @@ def remove_ads(
     path_file_hit = path.parent / f".hit.{path.name}.txt"
 
     if path_file_hit.exists() and not overwrite:
-        print("Already hit")
+        logger.debug("Already processed %s, skipping", file_name)
         return
 
-    print(f"Removing ads from {file_name}")
+    logger.info("Removing ads from %s", file_name)
 
     split_names = split_file(file_name)
     for split_name in tqdm(split_names, desc="Splitting parts"):
         trimmer = AdTrimmer(split_name, model=model)
         trimmer.remove_ads(notif_name=notif_name)
-    print("Joining parts")
+    logger.info("Joining parts for %s", file_name)
     join_files(file_name)
-    print("Done")
+    logger.info("Done processing %s", file_name)
     path_file_hit.write_text("")
 
 if __name__ == "__main__":

--- a/src/ad_begone/watch_directory.py
+++ b/src/ad_begone/watch_directory.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from time import sleep
 
@@ -7,7 +8,10 @@ import pydantic.v1 as pydantic
 import pydantic_argparse
 from tqdm import tqdm
 
+from .logging import setup_logging
 from .remove_ads import remove_ads
+
+logger = logging.getLogger(__name__)
 
 
 class WatchArgs(pydantic.BaseModel):
@@ -47,6 +51,8 @@ def walk_directory(
         )
 
 def main():
+    setup_logging()
+
     parser = pydantic_argparse.ArgumentParser(
         model=WatchArgs,
         description="Remove ads from a podcast episode.",
@@ -56,7 +62,7 @@ def main():
     while True:
         try:
             walk_directory(args.directory, model=args.model)
-            print(f"Sleeping for {int(args.sleep / 60)} minutes...")
+            logger.info("Sleeping for %d minutes", args.sleep // 60)
             sleep(args.sleep)
         except KeyboardInterrupt:
             break


### PR DESCRIPTION
## Summary
- Replace all `print()` calls with Python's `logging` module across `remove_ads.py`, `utils.py`, and `watch_directory.py`
- Add `src/ad_begone/logging.py` config module supporting `LOG_LEVEL` and `LOG_FORMAT` (text or JSON) env vars
- Set `PYTHONUNBUFFERED=1` in Dockerfile so logs flush immediately in containers
- Default to `LOG_FORMAT=json` in `compose.yml` for Docker log driver compatibility

Closes #36

## Test plan
- [x] All 84 existing unit tests pass (1 pre-existing pytest import error unrelated to this change)
- [ ] Run locally with `LOG_FORMAT=text` and verify human-readable output
- [ ] Run via `docker compose up` and verify JSON-formatted log lines
- [ ] Verify `LOG_LEVEL=DEBUG` surfaces skip messages for already-processed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)