### PR TITLE
Add logger.error() before raising exceptions

### DIFF
--- a/src/ad_begone/ad_trimmer.py
+++ b/src/ad_begone/ad_trimmer.py
@@ -1,3 +1,5 @@
+import logging
+
 from openai.types.audio.transcription_verbose import TranscriptionVerbose
 from openai.types.chat.parsed_chat_completion import ParsedChatCompletion
 
@@ -12,6 +14,8 @@ from .utils import (
 
 from .notif_path import NOTIF_PATH
 
+logger = logging.getLogger(__name__)
+
 
 class AdTrimmer:
 
@@ -19,6 +23,7 @@ class AdTrimmer:
         self.file_name = file_name
         self.model = model
         if not file_name.endswith(".mp3"):
+            logger.error("Invalid file extension for AdTrimmer: %s", file_name)
             raise ValueError("File name must end with .mp3")
         self.transcription_cache_file = file_name + ".transcription.json"
         self.segments_cache_file = file_name + ".segments.json"

--- a/src/ad_begone/utils.py
+++ b/src/ad_begone/utils.py
@@ -30,6 +30,7 @@ def cached_transcription(
     file_transcription: str | None = None,
 ) -> TranscriptionVerbose:
     if ".mp3" not in file_name:
+        logger.error("Invalid file type for transcription: %s", file_name)
         raise ValueError("Couldn't find valid file")
 
     if file_transcription is None:
@@ -92,6 +93,7 @@ def _get_model() -> str:
         reverse=True,
     )
     if not gpt_models:
+        logger.error("No chat-capable GPT models available from the OpenAI API")
         raise RuntimeError("No chat-capable GPT models available from the OpenAI API")
     _RESOLVED_MODEL = gpt_models[0].id
     logger.warning("No OPENAI_MODEL set, using %s", _RESOLVED_MODEL)
@@ -199,6 +201,7 @@ def _remove_ads(
 
     if out_name is None:
         if "part_" not in file_name:
+            logger.error("Refusing to overwrite non-part file without explicit out_name: %s", file_name)
             raise ValueError("Destructive")
         out_name = file_name
 


### PR DESCRIPTION
## Summary
- Add `logger.error()` calls before each `raise` in `utils.py` and `ad_trimmer.py`
- Ensures failures are visible in container logs even when tracebacks are truncated or exceptions are caught upstream

**Affected sites:**
| File | Error | Context logged |
|------|-------|----------------|
| `utils.py:33` | `ValueError` — invalid file type | File name |
| `utils.py:95` | `RuntimeError` — no GPT models | - |
| `utils.py:202` | `ValueError` — destructive overwrite | File name |
| `ad_trimmer.py:22` | `ValueError` — wrong extension | File name |

## Test plan
- [x] All 84 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)