### PR TITLE
Suppress pydub SyntaxWarning on Python 3.12+

### DIFF
--- a/src/ad_begone/__init__.py
+++ b/src/ad_begone/__init__.py
@@ -1,0 +1,3 @@
+import warnings
+
+warnings.filterwarnings("ignore", category=SyntaxWarning, module=r".*pydub")


### PR DESCRIPTION
## Summary
- Adds a `warnings.filterwarnings` call in `__init__.py` to suppress `SyntaxWarning` from pydub's invalid escape sequences
- Uses `module=r".*pydub"` regex because compile-time SyntaxWarnings report the full filesystem path as the module name, not the Python module name
- Filter is placed in `__init__.py` so it runs before any submodule imports pydub

Closes #46

## Test plan
- [x] Verified warnings are suppressed (even with `-W all`)
- [x] Verified warnings appear without the filter (control test)
- [x] Existing test suite passes (84/85, pre-existing unrelated failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)