### PR TITLE
Improve logging: ad summary, excerpts, elapsed time, remove tqdm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "openai>=1.63.0",
     "pydantic-argparse>=0.10.0",
     "pydub>=0.25.1",
-    "tqdm>=4.67.1",
 ]
 
 [project.scripts]

--- a/src/ad_begone/remove_ads.py
+++ b/src/ad_begone/remove_ads.py
@@ -1,6 +1,6 @@
 import logging
+import time
 from pathlib import Path
-from tqdm import tqdm
 
 from .ad_trimmer import AdTrimmer
 from .utils import join_files, split_file
@@ -27,14 +27,19 @@ def remove_ads(
         return
 
     logger.info("Removing ads from %s", file_name)
+    start_time = time.monotonic()
 
     split_names = split_file(file_name)
-    for split_name in tqdm(split_names, desc="Splitting parts"):
+    for i, split_name in enumerate(split_names, 1):
+        logger.info("Processing part %d/%d for %s", i, len(split_names), file_name)
         trimmer = AdTrimmer(split_name, model=model)
         trimmer.remove_ads(notif_name=notif_name)
     logger.info("Joining parts for %s", file_name)
     join_files(file_name)
-    logger.info("Done processing %s", file_name)
+
+    elapsed = time.monotonic() - start_time
+    minutes, seconds = divmod(elapsed, 60)
+    logger.info("Done processing %s (elapsed: %dm %ds)", file_name, int(minutes), int(seconds))
     path_file_hit.write_text("")
 
 if __name__ == "__main__":

--- a/src/ad_begone/watch_directory.py
+++ b/src/ad_begone/watch_directory.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import pydantic.v1 as pydantic
 import pydantic_argparse
-from tqdm import tqdm
 
 from .logging import setup_logging
 from .remove_ads import remove_ads
@@ -43,7 +42,9 @@ def walk_directory(
             continue
         queue.append(fn)
 
-    for fn in tqdm(queue, desc="Podcasts to process"):
+    logger.info("Found %d podcast(s) to process", len(queue))
+    for i, fn in enumerate(queue, 1):
+        logger.info("Processing podcast %d/%d: %s", i, len(queue), fn)
         remove_ads(
             file_name=str(fn),
             overwrite=overwrite,

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,6 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic-argparse" },
     { name = "pydub" },
-    { name = "tqdm" },
 ]
 
 [package.metadata]
@@ -20,7 +19,6 @@ requires-dist = [
     { name = "openai", specifier = ">=1.63.0" },
     { name = "pydantic-argparse", specifier = ">=0.10.0" },
     { name = "pydub", specifier = ">=0.25.1" },
-    { name = "tqdm", specifier = ">=4.67.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Log total ad time removed and first/last 20 words of each detected ad segment per file part
- Track and log elapsed wall-clock time for processing each podcast
- Replace `tqdm` progress bars with structured log statements in both `remove_ads.py` and `watch_directory.py`
- Remove `tqdm` dependency from `pyproject.toml`

Closes #50

## Test plan
- [x] All 85 existing tests pass
- [ ] Run against a real podcast and verify log output includes ad excerpts, time summaries, and elapsed time
- [ ] Verify no tqdm output appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)